### PR TITLE
Use libc::setlocale

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,7 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 name = "rcui"
 version = "0.1.0"
 dependencies = [
+ "libc",
  "ncurses",
  "pdcurses",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[dependencies]
+libc = "0.2.80"
 [target.'cfg(unix)'.dependencies]
 ncurses = { version = "5.99.0", features = ["wide"] }
 [target.'cfg(windows)'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,9 @@ impl Rcui {
     pub fn exec(mut ui: Box<dyn Widget>) {
         let mut context = Self::new();
 
-        let locale_conf = LcCategory::all;
-        setlocale(locale_conf, "en_US.UTF-8");
+        unsafe {
+            libc::setlocale(libc::LC_ALL, "en_US.UTF-8\0".as_ptr().cast());
+        }
 
         initscr();
         keypad(stdscr(), true);


### PR DESCRIPTION
pdcurses does not provides a special unnecessary wrapper for setlocale.