### PR TITLE
Re-export [n|pd]curses as `rcui::curses`

### DIFF
--- a/examples/05_edit_field.rs
+++ b/examples/05_edit_field.rs
@@ -1,4 +1,4 @@
-use ncurses::*;
+use rcui::curses::*;
 use rcui::*;
 
 fn main() {

--- a/src/curses.rs
+++ b/src/curses.rs
@@ -1,0 +1,4 @@
+#[cfg(unix)]
+pub use ncurses::*;
+#[cfg(windows)]
+pub use pdcurses::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod column;
+pub mod curses;
 mod dummy;
 mod edit_field;
 mod group;
@@ -8,14 +9,8 @@ mod row;
 pub mod style;
 mod text;
 
-#[cfg(unix)]
-use ncurses::CURSOR_VISIBILITY::*;
-#[cfg(unix)]
-use ncurses::*;
-#[cfg(windows)]
-use pdcurses::CURSOR_VISIBILITY::*;
-#[cfg(windows)]
-use pdcurses::*;
+use curses::CURSOR_VISIBILITY::*;
+use curses::*;
 use std::collections::VecDeque;
 use std::panic::{set_hook, take_hook};
 


### PR DESCRIPTION
Otherwise, applications using `rcui` will have to unnecessary bother with conditional dependencies.